### PR TITLE
Error out when there's no result for a word

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var cheerio = require("cheerio");
 var async = require("async");
 var Promise = require('bluebird');
 
+const noresults = "wordPage noresults"
+
 var Word = function(word){
   this.name = word;
   this.vocabDotComUrl = url(word);
@@ -103,6 +105,10 @@ function addMnemonicToWordObject(wordObj, callback){
 }
 function getVocabDotComDOM(word, callback){
   request(url(word), function (error, response, body) {
+    // If body contains "wordPage noresults", it's an error.
+    if (body.includes(noresults)) {
+      error = new Error("word not found")
+    }
     if (!error) {
       // var $ = cheerio.load(body)
       // var  def = $("p.short").text();


### PR DESCRIPTION
I use https://www.npmjs.com/package/english-dictionary-cli and I got struck by this weird error
```
Unhandled rejection SyntaxError: Unexpected token u in JSON at position 0
```
On investigating, found that it's happening due to no results for the word.

It would be great if [english-dictionary-cli](https://www.npmjs.com/package/english-dictionary-cli) is rebuilt with this change and re-published. I love using it ❤️

fixes #2 